### PR TITLE
Unit tests

### DIFF
--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -68,9 +68,9 @@ def get_indexes_to_remove(df, parameter):
     for submission_no in df.submission.unique():
         parameter_max = df.loc[df["submission"]==submission_no][parameter].max()
         if len(df.loc[(df["submission"]==submission_no) & (df[parameter] == parameter_max)]) > 1:
-            print(f"Submision {submission_no} is duplicated and has the same {parameter} value\n"
-                    f"Skipping submision {submission_no}" )
-            # if duplicate submissions share the maximum paramter value add the all 
+            warnings.warn(f"Submision {submission_no} is duplicated and has the same "
+                          f"{parameter} value\nSkipping submision {submission_no}")
+            # if duplicate submissions share the maximum paramter value add all 
             # entries with submission_no to the list of indexes to remove
             indexes = indexes.append(df.loc[df["submission"]==submission_no].index)
         else:
@@ -148,16 +148,16 @@ def filter_columns_numeric(df, **kwargs):
         # ensures that values are of length 2 (min & max) and numeric
         if (not isinstance(value, list) and not isinstance(value,tuple)) or len(value) != 2 \
             or (not isinstance(value[0], float) and not isinstance(value[0], int)) \
-            or (not isinstance(value[1], float) and not isinstance(value[1], int)):
-            raise ValueError(f"Invalid kwarg '{column_name}': must be list or tuple" 
-                              " of numeric type and length 2")
+            or (not isinstance(value[1], float) and not isinstance(value[1], int)) \
+            or value[0] >= value[1]:
+            raise ValueError(f"Invalid kwarg '{column_name}': must be list or tuple of 2" 
+                              " numbers where the 2nd element is larger than the 1st")
     # constructs a query string on which to query df; e.g. 'pcMapped >= 90 and 
     # pcMapped <= 100 and GenomeCov >= 80 and GenomveCov <= 100'
     query = ' and '.join(f'{col} >= {vals[0]} and {col} <= {vals[1]}' \
         for col, vals in kwargs.items())
     return df.query(query)
 
-# TODO: warning if any value is not in the specified column
 def filter_columns_categorical(df, **kwargs):
     """ 
         Filters the summary dataframe according to kwargs, where keys
@@ -248,7 +248,6 @@ def build_multi_fasta(multi_fasta_path, df):
                 print(f"Check results objects in row {index} of btb_wgs_sample.csv")
                 raise e
 
-#TODO: unit test maybe?
 def snp_sites(output_prefix, multi_fasta_path):
     """
         Run snp-sites on consensus files
@@ -257,7 +256,6 @@ def snp_sites(output_prefix, multi_fasta_path):
     cmd = f'snp-sites {multi_fasta_path} -c -o {output_prefix}_snpsites.fas'
     utils.run(cmd, shell=True)
 
-#TODO: unit test maybe?
 def snp_dists(output_prefix):
     """
         Run snp-dists

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -169,8 +169,8 @@ def filter_columns_categorical(df, **kwargs):
             pd.api.types.is_object_dtype(df[column_name])):
             raise InvalidDtype(dtype="category or object", column_name=column_name)
         # ensures that values are of type list
-        if not isinstance(value, list):
-            raise ValueError(f"Invalid kwarg '{column_name}': must be of type list")
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError(f"Invalid kwarg '{column_name}': must be a list of strings")
     # constructs a query string on which to query df; e.g. 'Outcome in [Pass] and 
     # sample_name in ["AFT-61-03769-21", "20-0620719"]. 
     query = ' and '.join(f'{col} in {vals}' for col, vals in kwargs.items())

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -145,9 +145,9 @@ def filter_columns_numeric(df, **kwargs):
         if not pd.api.types.is_numeric_dtype(df[column_name]):
             raise InvalidDtype(dtype="float or int", column_name=column_name)
         # ensures that values are of length 2 (min & max) and numeric
-        if (not type(value) is list and not type(value) is tuple) or len(value) != 2 or \
-           (not type(value[0]) is float and not type(value[0]) is int) or\
-           (not type(value[1]) is float and not type(value[1]) is int):
+        if (not isinstance(value, list) and not isinstance(value,tuple)) or len(value) != 2 \
+            or (not isinstance(value[0], float) and not isinstance(value[0], int)) \
+            or (not isinstance(value[1], float) and not isinstance(value[1], int)):
             raise ValueError(f"Invalid kwarg '{column_name}': must be list or tuple" 
                               " of numeric type and length 2")
     # constructs a query string on which to query df; e.g. 'pcMapped >= 90 and 

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -55,9 +55,9 @@ def get_indexes_to_remove(df, parameter):
         for duplicate submisions which should be excluded.
 
         Parameters:
-            df (pandas dataframe object): a dataframe read from btb_wgs_samples.csv
+            df (pandas DataFrame object): a dataframe read from btb_wgs_samples.csv
 
-            parameter (string): a column name from df on which to decide which 
+            parameter (str): a column name from df on which to decide which 
             duplicate to keep, e.g. keep the submission with the largest pcMapped
 
         Returns:
@@ -85,7 +85,7 @@ def filter_df(df, pcmap_threshold=(0,100), **kwargs):
         btb_wgs_samples.csv according to a set of criteria. 
 
         Parameters:
-            df (pandas dataframe object): a dataframe read from btb_wgs_samples.csv.
+            df (pandas DataFrame object): a dataframe read from btb_wgs_samples.csv.
 
             pcmap_threshold (tuple): min and max thresholds for pcMapped
 
@@ -100,9 +100,11 @@ def filter_df(df, pcmap_threshold=(0,100), **kwargs):
             min and max value for that column. 
 
         Returns:
-            df_filtered (pandas dataframe object): a dataframe of 'Pass'
+            df_filtered (pandas DataFrame object): a dataframe of 'Pass'
             only samples filtered according to criteria set out in 
             arguments.
+
+            ValueError: if any kwarg is not in df.columns  
     """
     # add "Pass" only samples and pcmap_theshold to the filtering 
     # criteria by default
@@ -130,6 +132,7 @@ def filter_df(df, pcmap_threshold=(0,100), **kwargs):
         raise Exception("0 samples meet specified criteria")
     return df_filtered
     
+# TODO: raise exception if second element is smaller than first
 def filter_columns_numeric(df, **kwargs):
     """ 
         Filters the summary dataframe according to kwargs, where keys
@@ -150,6 +153,7 @@ def filter_columns_numeric(df, **kwargs):
         for col, vals in kwargs.items())
     return df.query(query)
 
+# TODO: warning if any value is not in the specified column
 def filter_columns_categorical(df, **kwargs):
     """ 
         Filters the summary dataframe according to kwargs, where keys
@@ -184,7 +188,6 @@ def get_samples_df(bucket=DEFAULT_RESULTS_BUCKET, summary_key=DEFAULT_SUMMARY_KE
                                                          **kwargs).pipe(remove_duplicates)
     return df
 
-# TODO: unit test
 def append_multi_fasta(s3_uri, outfile):
     """
         Appends a multi fasta file with the consensus sequence stored at s3_uri
@@ -205,8 +208,23 @@ def append_multi_fasta(s3_uri, outfile):
         with open(consensus_filepath, 'rb') as consensus_file:
             outfile.write(consensus_file.read())
 
-#TODO: unit test - use mocking
 def build_multi_fasta(multi_fasta_path, df):
+    """
+        Builds the multi fasta constructed from consensus sequences for all 
+        samples in df
+
+        Parameters:
+            multi_fasta_path (str): path for location of multi fasta sequence
+            (appended consensus sequences for all samples)
+
+            df (pandas DataFrame object): dataframe containing s3_uri for 
+            consensus sequences of samples to be included in phylogeny
+
+        Raises:
+            utils.NoS3ObjectError: if the object cannot be found in the 
+            specified s3 bucket
+    
+    """
     with open(multi_fasta_path, 'wb') as outfile:
         # loops through all samples to be included in phylogeny
         for index, sample in df.iterrows():

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -110,7 +110,7 @@ def filter_df(df, pcmap_threshold=(0,100), **kwargs):
     numerical_kwargs = {"pcMapped": pcmap_threshold}
     for key in kwargs.keys():
         if key not in df.columns:
-            raise ValueError(f"Inavlid kwarg '{key}': must be one of: " 
+            raise ValueError(f"Invalid kwarg '{key}': must be one of: " 
                              f"{', '.join(df.columns.to_list())}")
         else:
             if pd.api.types.is_categorical_dtype(df[key]) or \
@@ -242,7 +242,7 @@ def snp_dists(output_prefix):
 def main():
     multi_fasta_path = "/home/nickpestell/tmp/test_multi_fasta.fas"
     output_prefix = "/home/nickpestell/tmp/snps"
-    samples_df = get_samples_df()
+    samples_df = get_samples_df("s3-staging-area", "nickpestell/summary_test_v3.csv")
     # TODO: make multi_fasta_path a tempfile and pass file object into build_multi_fasta
     build_multi_fasta(multi_fasta_path, samples_df)
     snp_sites(output_prefix, multi_fasta_path)

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -147,9 +147,9 @@ def filter_columns_numeric(df, **kwargs):
         # ensures that values are of length 2 (min & max)
         if len(value) != 2:
             raise ValueError(f"Invalid kwarg '{column_name}': must be of length 2")
-    # constructs a query string on which to query df; e.g. 'pcMapped > 90 and 
-    # pcMapped < 100 and GenomeCov > 80 and GenomveCov < 100'
-    query = ' and '.join(f'{col} > {vals[0]} and {col} < {vals[1]}' \
+    # constructs a query string on which to query df; e.g. 'pcMapped >= 90 and 
+    # pcMapped <= 100 and GenomeCov >= 80 and GenomveCov <= 100'
+    query = ' and '.join(f'{col} >= {vals[0]} and {col} <= {vals[1]}' \
         for col, vals in kwargs.items())
     return df.query(query)
 

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -147,6 +147,9 @@ def filter_columns_numeric(df, **kwargs):
         # ensures that values are of length 2 (min & max)
         if len(value) != 2:
             raise ValueError(f"Invalid kwarg '{column_name}': must be of length 2")
+        if not type(value[0]) is float and not type(value[0]) is int or\
+            not type(value[1]) is float and not type(value[1]) is int:
+            raise ValueError(f"Invalid kwarg: '{column_name}': elements must be numeric")
     # constructs a query string on which to query df; e.g. 'pcMapped >= 90 and 
     # pcMapped <= 100 and GenomeCov >= 80 and GenomveCov <= 100'
     query = ' and '.join(f'{col} >= {vals[0]} and {col} <= {vals[1]}' \

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -1,6 +1,7 @@
 import tempfile
 import os
 import pandas as pd
+import warnings
 
 import utils
 
@@ -168,9 +169,14 @@ def filter_columns_categorical(df, **kwargs):
         if not (pd.api.types.is_categorical_dtype(df[column_name]) or \
             pd.api.types.is_object_dtype(df[column_name])):
             raise InvalidDtype(dtype="category or object", column_name=column_name)
-        # ensures that values are of type list
+        # ensures that values are list of strings
         if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
             raise ValueError(f"Invalid kwarg '{column_name}': must be a list of strings")
+        # issues a warning if any value is missing from specified column
+        missing_values = [item for item in value if item not in list(df[column_name])]
+        if missing_values:
+            warnings.warn(f"Column '{column_name}' does not contain the values "
+                          f"'{', '.join(missing_values)}'")
     # constructs a query string on which to query df; e.g. 'Outcome in [Pass] and 
     # sample_name in ["AFT-61-03769-21", "20-0620719"]. 
     query = ' and '.join(f'{col} in {vals}' for col, vals in kwargs.items())

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -144,12 +144,12 @@ def filter_columns_numeric(df, **kwargs):
         # ensures that column_names are of numeric type
         if not pd.api.types.is_numeric_dtype(df[column_name]):
             raise InvalidDtype(dtype="float or int", column_name=column_name)
-        # ensures that values are of length 2 (min & max)
-        if len(value) != 2:
-            raise ValueError(f"Invalid kwarg '{column_name}': must be of length 2")
-        if not type(value[0]) is float and not type(value[0]) is int or\
-            not type(value[1]) is float and not type(value[1]) is int:
-            raise ValueError(f"Invalid kwarg: '{column_name}': elements must be numeric")
+        # ensures that values are of length 2 (min & max) and numeric
+        if (not type(value) is list and not type(value) is tuple) or len(value) != 2 or \
+           (not type(value[0]) is float and not type(value[0]) is int) or\
+           (not type(value[1]) is float and not type(value[1]) is int):
+            raise ValueError(f"Invalid kwarg '{column_name}': must be list or tuple" 
+                              " of numeric type and length 2")
     # constructs a query string on which to query df; e.g. 'pcMapped >= 90 and 
     # pcMapped <= 100 and GenomeCov >= 80 and GenomveCov <= 100'
     query = ' and '.join(f'{col} >= {vals[0]} and {col} <= {vals[1]}' \

--- a/build_snp_matrix.py
+++ b/build_snp_matrix.py
@@ -212,7 +212,7 @@ def build_multi_fasta(multi_fasta_path, df):
         for index, sample in df.iterrows():
             try:
                 consensus_key = os.path.join(sample["results_prefix"], "consensus", 
-                                            sample["sample_name"])
+                                             sample["sample_name"])
                 # appends sample's consensus sequence to multifasta
                 append_multi_fasta((sample["results_bucket"], consensus_key+"_consensus.fas"), outfile)
             except utils.NoS3ObjectError as e:

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -31,16 +31,16 @@ class TestBuildSnpMatrix(unittest.TestCase):
         test_df = pd.DataFrame({"column_A":pd.Series(["a", "b", "c", "d", "e"], dtype="object"),
                                 "Outcome":pd.Series(["A", "Pass", "Pass", "Pass", "Pass"], dtype="category"), 
                                 "pcMapped":pd.Series([0.1, 0.2, 0.3, 0.4, 0.5], dtype=float),
-                                "column_D":pd.Series([1, 2, 3, 4, 5], dtype=int)})
+                                "column_D":pd.Series([1, 3, 5, 7, 9], dtype=int)})
         # test multiple filters
         outcome = build_snp_matrix.filter_df(test_df, pcmap_threshold=(0.15, 0.45), 
-                                                  column_A=["b", "c"], column_D=(1, 3)) 
+                                                  column_A=["b", "c"], column_D=(2, 4)) 
         nptesting.assert_array_equal(outcome.values, pd.DataFrame({"column_A":["b"], "Outcome":["Pass"],
-                                     "pcMapped":[0.2], "column_D":[2]}).values)
+                                     "pcMapped":[0.2], "column_D":[3]}).values)
         # test empty output
         with self.assertRaises(Exception):
-            build_snp_matrix.filter_df(test_df, pcmap_threshold=(0.15, 0.45), 
-                                       column_A=["b", "c"], column_D=(2.5, 3))
+            build_snp_matrix.filter_df(test_df, pcmap_threshold=(0.15, 0.16), 
+                                       column_A=["b", "c"], column_D=(2, 3))
         with self.assertRaises(ValueError):
             # invalid kwarg name
             build_snp_matrix.filter_df(test_df, foo="foo")
@@ -50,26 +50,26 @@ class TestBuildSnpMatrix(unittest.TestCase):
         test_df = pd.DataFrame({"column_A":pd.Series(["a", "b", "c", "d"], dtype="category"),
                                 "column_B":pd.Series(["A", "B", "C", "D"], dtype=object), 
                                 "column_C":pd.Series([0.1, 0.2, 0.3, 0.4], dtype=float),
-                                "column_D":pd.Series([1, 2, 3, 4,], dtype=int)})
+                                "column_D":pd.Series([1, 3, 5, 7,], dtype=int)})
         # test filter on float series
-        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, column_C=(0.1, 0.4)).values,
+        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, column_C=(0.15, 0.35)).values,
                                      pd.DataFrame({"column_A":["b", "c"], "column_B":["B", "C"], 
-                                                   "column_C":[0.2, 0.3], "column_D":[2, 3]}).values)
+                                                   "column_C":[0.2, 0.3], "column_D":[3, 5]}).values)
         # test filter on int series
-        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, column_D=(1, 4)).values,
+        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, column_D=(2, 6)).values,
                                       pd.DataFrame({"column_A":["b", "c"], "column_B":["B", "C"], 
-                                                    "column_C":[0.2, 0.3], "column_D":[2, 3]}).values)
+                                                    "column_C":[0.2, 0.3], "column_D":[3, 5]}).values)
         # test filter on multiple series
-        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, column_D=(1, 4),
-                                                                             column_C=(0.2, 0.4)).values,
-                                     pd.DataFrame({"column_A":["c"], "column_B":["C"], 
-                                                   "column_C":[0.3], "column_D":[3]}).values)
-        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, **{"column_D": (1, 4),
-                                                                             "column_C": (0.1, 0.3)}).values,
+        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, column_D=(2, 4),
+                                                                             column_C=(0.05, 0.35)).values,
                                      pd.DataFrame({"column_A":["b"], "column_B":["B"], 
-                                                   "column_C":[0.2], "column_D":[2]}).values)
+                                                   "column_C":[0.2], "column_D":[3]}).values)
+        nptesting.assert_array_equal(build_snp_matrix.filter_columns_numeric(test_df, **{"column_D": (3, 8),
+                                                                             "column_C": (0.25, 0.35)}).values,
+                                     pd.DataFrame({"column_A":["c"], "column_B":["C"], 
+                                                   "column_C":[0.3], "column_D":[5]}).values)
         # test empty output
-        self.assertTrue(build_snp_matrix.filter_columns_numeric(test_df, column_D=(2, 3)).empty)
+        self.assertTrue(build_snp_matrix.filter_columns_numeric(test_df, column_C=(0.23, 0.24)).empty)
         # test exceptions
         with self.assertRaises(build_snp_matrix.InvalidDtype):
             build_snp_matrix.filter_columns_numeric(test_df, column_A="foo")

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -9,10 +9,17 @@ import numpy.testing as nptesting
 
 import build_snp_matrix
 
-class TestBuildSnpMatrix(unittest.TestCase):
-    def test_build_multi_fasta(self):
-        pass
+TEST_MULTIFASTA_PATH = "test_files/test_multifasta.fas"
 
+class TestBuildSnpMatrix(unittest.TestCase):
+#    @classmethod
+#    def setUpClass(cls):
+#        cls.test_multifasta_file = open(TEST_MULTIFASTA_PATH, 'r')
+#
+#    @classmethod
+#    def tearDownClass(cls):
+#        cls.test_multifasta_file.close()
+#
     def test_remove_duplicates(self):
         # define dataframe for input
         test_df = pd.DataFrame({"submission":pd.Series(["1", "2", "2", "2", "1", "3"], dtype="object"),
@@ -122,19 +129,17 @@ class TestBuildSnpMatrix(unittest.TestCase):
             build_snp_matrix.filter_columns_categorical(test_df, column_A="a")
             build_snp_matrix.filter_columns_categorical(test_df, column_B=("A", "Pass"))
 
-    def test_append_multi_fasta(self):
-        build_snp_matrix.utils.s3_download_file = mock.Mock()
-        with tempfile.TemporaryDirectory() as temp_dirname:
-            testfile_path = os.path.join(temp_dirname, "test.txt")
-            with mock.mock_open(read_data="hello world"):
-                build_snp_matrix.append_multi_fasta("foo", testfile_path)
-            self.assertTrue()
-
-        pass
-    
     def test_build_multi_fasta(self):
-        pass
-
+        test_df = pd.DataFrame({"sample_name": ["A", "B", "C"], "results_prefix": ["a", "b", "c"], 
+                                "results_bucket": ["foo", "bar", "baz"]})
+        build_snp_matrix.utils.s3_download_file = mock.Mock()
+        mock_open =  mock.mock_open(read_data="hello world")
+        with mock.patch("builtins.open", mock_open):
+            build_snp_matrix.build_multi_fasta("foo", test_df)
+        calls = [unittest.mock.call("foo", "wb"), unittest.mock.call(unittest.mock.ANY, "rb"), 
+                 unittest.mock.call(unittest.mock.ANY, "rb"), unittest.mock.call(unittest.mock.ANY, "rb")]
+        mock_open.assert_has_calls(calls)
+    
     def snp_sites(self):
         pass
 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -29,9 +29,19 @@ class TestBuildSnpMatrix(unittest.TestCase):
     def test_filter_df(self):
         # define dataframe for input
         test_df = pd.DataFrame({"column_A":pd.Series(["a", "b", "c", "d", "e"], dtype="object"),
-                                "Outcome":pd.Series(["A", "Pass", "Pass", "Pass", "Pass"], dtype="category"), 
+                                "Outcome":pd.Series(["Fail", "Pass", "Pass", "Pass", "Pass"], dtype="category"), 
                                 "pcMapped":pd.Series([0.1, 0.2, 0.3, 0.4, 0.5], dtype=float),
                                 "column_D":pd.Series([1, 3, 5, 7, 9], dtype=int)})
+        # test individual filters
+        outcome = build_snp_matrix.filter_df(test_df, pcmap_threshold=(0.1, 0.3))
+        nptesting.assert_array_equal(outcome.values, pd.DataFrame({"column_A":["b", "c"], "Outcome":["Pass", "Pass"],
+                                     "pcMapped":[0.2, 0.3], "column_D":[3, 5]}).values)
+        outcome = build_snp_matrix.filter_df(test_df, column_A=["a", "e"])
+        nptesting.assert_array_equal(outcome.values, pd.DataFrame({"column_A":["e"], "Outcome":["Pass"],
+                                     "pcMapped":[0.5], "column_D":[9]}).values)
+        outcome = build_snp_matrix.filter_df(test_df, column_D=(7, 10))
+        nptesting.assert_array_equal(outcome.values, pd.DataFrame({"column_A":["d", "e"], "Outcome":["Pass", "Pass"],
+                                     "pcMapped":[0.4, 0.5], "column_D":[7, 9]}).values)
         # test multiple filters
         outcome = build_snp_matrix.filter_df(test_df, pcmap_threshold=(0.15, 0.45), 
                                                   column_A=["b", "c"], column_D=(2, 4)) 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,4 +1,8 @@
 import unittest
+import tempfile
+from unittest import mock
+import os
+import filecmp
 
 import pandas as pd
 import numpy.testing as nptesting
@@ -118,13 +122,23 @@ class TestBuildSnpMatrix(unittest.TestCase):
             build_snp_matrix.filter_columns_categorical(test_df, column_A="a")
             build_snp_matrix.filter_columns_categorical(test_df, column_B=("A", "Pass"))
 
+    def test_append_multi_fasta(self):
+        build_snp_matrix.utils.s3_download_file = mock.Mock()
+        with tempfile.TemporaryDirectory() as temp_dirname:
+            testfile_path = os.path.join(temp_dirname, "test.txt")
+            with mock.mock_open(read_data="hello world"):
+                build_snp_matrix.append_multi_fasta("foo", testfile_path)
+            self.assertTrue()
+
+        pass
+    
     def test_build_multi_fasta(self):
         pass
 
-    def test_append_multi_fasta(self):
+    def snp_sites(self):
         pass
-    
-    def test_snps(self):
+
+    def snp_dists(self):
         pass
 
 if __name__ == "__main__":

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -24,7 +24,6 @@ class TestBuildSnpMatrix(unittest.TestCase):
         pd.testing.assert_index_equal(build_snp_matrix.get_indexes_to_remove(test_df, "pcMapped"),
                                       pd.Index([0, 1, 2, 4]), check_order=False)
 
-    # TODO: test individual filters, i.e. with only one kwarg
     # TODO: think of more test cases
     def test_filter_df(self):
         # define dataframe for input
@@ -52,10 +51,21 @@ class TestBuildSnpMatrix(unittest.TestCase):
             build_snp_matrix.filter_df(test_df, pcmap_threshold=(0.15, 0.16), 
                                        column_A=["b", "c"], column_D=(2, 3))
         with self.assertRaises(ValueError):
-            # invalid kwarg name
+            # test invalid kwarg name
             build_snp_matrix.filter_df(test_df, foo="foo")
+            # test invalid arg types
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_df(test_df, column_A="a")
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_df(test_df, column_A=("a","b"))
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_df(test_df, column_D="foo")
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_df(test_df, column_D=("foo",))
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_df(test_df, column_D=("foo", "bar"))
 
-    def test_filter_column_numeric(self):
+    def test_filter_columns_numeric(self):
         # define dataframe for input
         test_df = pd.DataFrame({"column_A":pd.Series(["a", "b", "c", "d"], dtype="category"),
                                 "column_B":pd.Series(["A", "B", "C", "D"], dtype=object), 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -50,20 +50,9 @@ class TestBuildSnpMatrix(unittest.TestCase):
         with self.assertRaises(Exception):
             build_snp_matrix.filter_df(test_df, pcmap_threshold=(0.15, 0.16), 
                                        column_A=["b", "c"], column_D=(2, 3))
+        # test invalid kwarg name
         with self.assertRaises(ValueError):
-            # test invalid kwarg name
             build_snp_matrix.filter_df(test_df, foo="foo")
-            # test invalid arg types
-        with self.assertRaises(ValueError):
-            build_snp_matrix.filter_df(test_df, column_A="a")
-        with self.assertRaises(ValueError):
-            build_snp_matrix.filter_df(test_df, column_A=("a","b"))
-        with self.assertRaises(ValueError):
-            build_snp_matrix.filter_df(test_df, column_D="foo")
-        with self.assertRaises(ValueError):
-            build_snp_matrix.filter_df(test_df, column_D=("foo",))
-        with self.assertRaises(ValueError):
-            build_snp_matrix.filter_df(test_df, column_D=("foo", "bar"))
 
     def test_filter_columns_numeric(self):
         # define dataframe for input
@@ -91,15 +80,32 @@ class TestBuildSnpMatrix(unittest.TestCase):
         # test empty output
         self.assertTrue(build_snp_matrix.filter_columns_numeric(test_df, column_C=(0.23, 0.24)).empty)
         # test exceptions
+        # invalid kwarg type
         with self.assertRaises(build_snp_matrix.InvalidDtype):
             build_snp_matrix.filter_columns_numeric(test_df, column_A="foo")
+        with self.assertRaises(build_snp_matrix.InvalidDtype):
             build_snp_matrix.filter_columns_numeric(test_df, column_B="foo")
+        # invlalid kwarg: is not in df.columns
         with self.assertRaises(KeyError):
             build_snp_matrix.filter_columns_numeric(test_df, foo="foo")
+        # invalid kwarg val: must be len(2)
         with self.assertRaises(ValueError):
-            # invalid kwarg val: must be len(2)
             build_snp_matrix.filter_columns_numeric(test_df, column_D=(1, ))
+        with self.assertRaises(ValueError):
             build_snp_matrix.filter_columns_numeric(test_df, column_D=(1, 2, 3))
+        # invalid kwarg val: must be type list or tuple
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_columns_numeric(test_df, column_D=1)
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_columns_numeric(test_df, column_D="foo")
+        # invalid kwarg val: must be len(2)
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_columns_numeric(test_df, column_D=("foo",))
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_columns_numeric(test_df, column_D=("foo", "bar", "baz"))
+        # invalid kwarg val: elements must be numeric 
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_columns_numeric(test_df, column_D=("foo", "bar"))
 
     def test_filter_columns_categorical(self):
         # define dataframe for input
@@ -127,14 +133,20 @@ class TestBuildSnpMatrix(unittest.TestCase):
         # test empty output
         self.assertTrue(build_snp_matrix.filter_columns_categorical(test_df, column_A=["E", "F"]).empty)
         # test exceptions
+        # invalid kwarg type
         with self.assertRaises(build_snp_matrix.InvalidDtype):
             build_snp_matrix.filter_columns_categorical(test_df, column_C=[])
+        # invalid kwarg type
+        with self.assertRaises(build_snp_matrix.InvalidDtype):
             build_snp_matrix.filter_columns_categorical(test_df, column_D=[])
+        # invlalid kwarg: is not in df.columns
         with self.assertRaises(KeyError):
             build_snp_matrix.filter_columns_categorical(test_df, foo="foo")
+        # invalid kwarg type: must be list
         with self.assertRaises(ValueError):
-            # invalid kwarg type: must be list
             build_snp_matrix.filter_columns_categorical(test_df, column_A="a")
+        # invalid kwarg type: must be list
+        with self.assertRaises(ValueError):
             build_snp_matrix.filter_columns_categorical(test_df, column_B=("A", "Pass"))
 
     def test_build_multi_fasta(self):

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -19,10 +19,15 @@ class TestBuildSnpMatrix(unittest.TestCase):
     def test_get_indexes_to_remove(self):
         # define dataframe for input
         test_df = pd.DataFrame({"submission":pd.Series(["1", "2", "2", "2", "1", "3"], dtype="object"),
-                                "pcMapped":pd.Series([0.1, 0.2, 0.3, 0.4, 0.1, 0.6], dtype=float)})
+                                "pcMapped":pd.Series([0.1, 0.2, 0.3, 0.4, 0.2, 0.6], dtype=float)})
         # test expected input
         pd.testing.assert_index_equal(build_snp_matrix.get_indexes_to_remove(test_df, "pcMapped"),
-                                      pd.Index([0, 1, 2, 4]), check_order=False)
+                                      pd.Index([0, 1, 2]), check_order=False)
+        # test warning
+        test_df = pd.DataFrame({"submission":pd.Series(["1", "2", "2", "2", "1", "3"], dtype="object"),
+                                "pcMapped":pd.Series([0.1, 0.2, 0.3, 0.4, 0.1, 0.6], dtype=float)})
+        with self.assertWarns(Warning):
+            build_snp_matrix.get_indexes_to_remove(test_df, "pcMapped")
 
     def test_filter_df(self):
         # define dataframe for input
@@ -105,6 +110,9 @@ class TestBuildSnpMatrix(unittest.TestCase):
         # invalid kwarg val: elements must be numeric 
         with self.assertRaises(ValueError):
             build_snp_matrix.filter_columns_numeric(test_df, column_D=("foo", "bar"))
+        # invalid kwarg val: elements must be in order min followed by max 
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_columns_numeric(test_df, column_D=(2, 1))
 
     def test_filter_columns_categorical(self):
         # define dataframe for input
@@ -191,4 +199,4 @@ class TestBuildSnpMatrix(unittest.TestCase):
         pass
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(buffer=True)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -24,7 +24,6 @@ class TestBuildSnpMatrix(unittest.TestCase):
         pd.testing.assert_index_equal(build_snp_matrix.get_indexes_to_remove(test_df, "pcMapped"),
                                       pd.Index([0, 1, 2, 4]), check_order=False)
 
-    # TODO: think of more test cases
     def test_filter_df(self):
         # define dataframe for input
         test_df = pd.DataFrame({"column_A":pd.Series(["a", "b", "c", "d", "e"], dtype="object"),
@@ -131,7 +130,12 @@ class TestBuildSnpMatrix(unittest.TestCase):
                                      pd.DataFrame({"column_A":["d"], "column_B":["D"], 
                                                    "column_C":[0.4], "column_D":[4]}).values)
         # test empty output
-        self.assertTrue(build_snp_matrix.filter_columns_categorical(test_df, column_A=["E", "F"]).empty)
+        self.assertTrue(build_snp_matrix.filter_columns_categorical(test_df, column_A=["a", "b"], 
+                                                                    column_B=["C", "D"]).empty)
+        # test warning
+        # kwarg value is missing in column
+        with self.assertWarns(Warning):
+            build_snp_matrix.filter_columns_categorical(test_df, column_A=["Z", "Y"], column_B=["x"])
         # test exceptions
         # invalid kwarg type
         with self.assertRaises(build_snp_matrix.InvalidDtype):

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -118,19 +118,20 @@ class TestBuildSnpMatrix(unittest.TestCase):
             build_snp_matrix.filter_columns_categorical(test_df, column_B=("A", "Pass"))
 
     def test_build_multi_fasta(self):
-        # test dataframe for input - 3 rows imitating three samples
+        # test dataframe for input - 4 rows imitating 4 samples
         test_df = pd.DataFrame({"sample_name": ["A", "B", "C", "D"], 
                                 "results_prefix": ["a", "b", "c", "d"], 
                                 "results_bucket": ["1", "2", "3", "4"]})
         mock_open =  mock.mock_open()
         # mock open.read() to return 4 mock consensus sequences
         mock_open().read.side_effect=["AAA\nAAA", "TTT\nTTT", "CCC\nCCC", "GGG\nGGG"]
+        # mock utils.s3_download_file
         build_snp_matrix.utils.s3_download_file = mock.Mock()
-        # run build_multi_fasta() with a patched open and test_df
+        # run build_multi_fasta() with test_df and a patched open
         with mock.patch("builtins.open", mock_open):
             build_snp_matrix.build_multi_fasta("foo", test_df)
-        # calls to open to test against -> 1 call for the multifasta ("foo") 
-        # and 4 calls for each consensus sequence
+        # calls to open to test against: 1 call for the output 
+        # multifasta ("foo") and 4 calls for each consensus sequence
         open_calls = [mock.call("foo", "wb"), 
                       mock.call(mock.ANY, "rb"), 
                       mock.call(mock.ANY, "rb"),  

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -6,7 +6,6 @@ import numpy.testing as nptesting
 
 import build_snp_matrix
 
-TEST_MULTIFASTA_PATH = "test_files/test_multifasta.fas"
 
 class TestBuildSnpMatrix(unittest.TestCase):
     def test_remove_duplicates(self):

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -145,9 +145,11 @@ class TestBuildSnpMatrix(unittest.TestCase):
         # invalid kwarg type: must be list
         with self.assertRaises(ValueError):
             build_snp_matrix.filter_columns_categorical(test_df, column_A="a")
-        # invalid kwarg type: must be list
         with self.assertRaises(ValueError):
             build_snp_matrix.filter_columns_categorical(test_df, column_B=("A", "Pass"))
+        # invalid kwarg type: must be list of strings
+        with self.assertRaises(ValueError):
+            build_snp_matrix.filter_columns_categorical(test_df, column_A=[1, 2, 3])
 
     def test_build_multi_fasta(self):
         # test dataframe for input - 4 rows imitating 4 samples

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,8 +1,5 @@
 import unittest
-import tempfile
 from unittest import mock
-import os
-import filecmp
 
 import pandas as pd
 import numpy.testing as nptesting
@@ -136,9 +133,12 @@ class TestBuildSnpMatrix(unittest.TestCase):
         mock_open =  mock.mock_open(read_data="hello world")
         with mock.patch("builtins.open", mock_open):
             build_snp_matrix.build_multi_fasta("foo", test_df)
-        calls = [unittest.mock.call("foo", "wb"), unittest.mock.call(unittest.mock.ANY, "rb"), 
-                 unittest.mock.call(unittest.mock.ANY, "rb"), unittest.mock.call(unittest.mock.ANY, "rb")]
-        mock_open.assert_has_calls(calls)
+        open_calls = [mock.call("foo", "wb"), mock.call(mock.ANY, "rb"), 
+                 mock.call(mock.ANY, "rb"),  mock.call(mock.ANY, "rb")]
+        mock_open.assert_has_calls(open_calls, any_order=True)
+        write_calls = [mock.call().write("hello world"), 
+                       mock.call().write("hello world"), mock.call().write("hello world")]
+        mock_open().write.assert_has_calls(write_calls)
     
     def snp_sites(self):
         pass

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,7 @@ class NoS3ObjectError(Exception):
     def __str__(self):
         return self.message
 
+# TODO: remove if unused
 def s3_folder_exists(bucket, path):
     """
         Returns true if the folder is in the S3 bucket. False otherwise
@@ -67,6 +68,7 @@ def run(cmd, *args, **kwargs):
     if "capture_output" in kwargs and kwargs["capture_output"]:
         return ps.stdout.decode().strip('\n')
 
+# TODO: remove if unused
 def s3_download_folder(bucket, key, dest):
     """
         Downloads s3 folder at the key-bucket pair (strings) to dest 


### PR DESCRIPTION
This PR introduces improves unit tests by adding additional test commands for testing edge cases of filtering. It also adds a test method test the `build_multi_fasta()` function. 

In `build_snp_matrix.py` there are additional checks on input `**kwargs` for filtering the sample set which raise exceptions or warnings. There are also additional comments.

I think this is sufficient in terms of unit tests. 