### PR TITLE
Dl new samples

### DIFF
--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -237,12 +237,9 @@ def append_multi_fasta(s3_bucket, s3_key, outfile, sample, consensus_path):
             outfile (file object): file object refering to the multi fasta output
             file
     """
-    # temp directory for storing individual consensus files - deleted when function
-    # returns
-    consensus_filepath = consensus_path + sample['Sample'] + '.fas'
-    if os.path.exists(consensus_filepath):
-        pass
-    else:
+    # check if file is already present in the consensus directory 
+    consensus_filepath = os.path.join(consensus_path , sample , '.fas')
+    if not os.path.exists(consensus_filepath):
         # dowload consensus file from s3 to tempfile
         utils.s3_download_file(s3_bucket, s3_key, consensus_filepath)
     # writes to multifasta
@@ -254,7 +251,7 @@ def build_multi_fasta(multi_fasta_path, df, consensus_path):
         Builds the multi fasta constructed from consensus sequences for all 
         samples in df
 
-        Parameters:
+        Parameters: 
             multi_fasta_path (str): path for location of multi fasta sequence
             (appended consensus sequences for all samples)
 
@@ -278,7 +275,7 @@ def build_multi_fasta(multi_fasta_path, df, consensus_path):
                 s3_bucket = extract_s3_bucket(sample["ResultLoc"])
                 consensus_key = extract_s3_key(sample["ResultLoc"], sample["Sample"])
                 # appends sample's consensus sequence to multifasta
-                append_multi_fasta(s3_bucket, consensus_key, outfile, sample, consensus_path)
+                append_multi_fasta(s3_bucket, consensus_key, outfile, sample["Sample"], consensus_path)
             except utils.NoS3ObjectError as e:
                 # if consensus file can't be found in s3, btb_wgs_samples.csv must be corrupted
                 print(e.message)
@@ -381,7 +378,7 @@ def main():
     multi_fasta_path = os.path.join(results_path, "multi_fasta.fas")
     snp_sites_outpath = os.path.join(results_path, "snps.fas")
     snp_dists_outpath = os.path.join(results_path, "snp_matrix.tab")
-    consensus_downloads = '/mnt/fsx-017/phyloConsensus/'
+    consensus_downloads = os.path.join(results_path, "phyloConsensus")
     tree_path = os.path.join(results_path, "mega")
     # get samples from btb_wgs_samples.csv and filter
     samples_df = get_samples_df("s3-staging-area", "nickpestell/btb_wgs_samples.csv", **kwargs)

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -353,7 +353,7 @@ def main():
     parser.add_argument("--n_count", "-nc", dest="Ncount", type=float, nargs=2)
     parser.add_argument("--flag", "-f", dest="flag", type=str, nargs="+")
     parser.add_argument("--meandepth", "-md", dest="MeanDepth", type=float, nargs=2)
-    parser.add_argument("fsx_path", help = "Path to fsx drive where consensus files will be held", default='/mnt/fsx-017/')
+    parser.add_argument("--fsx_path", help = "Path to fsx drive where consensus files will be held", default='/mnt/fsx-017/')
     # parse agrs
     clargs = vars(parser.parse_args())
     # retreive "non-filtering" args

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -353,6 +353,7 @@ def main():
     parser.add_argument("--n_count", "-nc", dest="Ncount", type=float, nargs=2)
     parser.add_argument("--flag", "-f", dest="flag", type=str, nargs="+")
     parser.add_argument("--meandepth", "-md", dest="MeanDepth", type=float, nargs=2)
+    parser.add_argument("fsx_path", help = "Path to fsx drive where consensus files will be held", default='/mnt/fsx-017/')
     # parse agrs
     clargs = vars(parser.parse_args())
     # retreive "non-filtering" args
@@ -360,6 +361,7 @@ def main():
     threads = clargs.pop("n_threads")
     tree = clargs.pop("build_tree")
     config = clargs.pop("config")
+    fsx = clargs.pop("fsx_path")
     # if config json file provided
     if config:
         error_keys = [key for key, val in clargs.items() if val]
@@ -378,7 +380,7 @@ def main():
     multi_fasta_path = os.path.join(results_path, "multi_fasta.fas")
     snp_sites_outpath = os.path.join(results_path, "snps.fas")
     snp_dists_outpath = os.path.join(results_path, "snp_matrix.tab")
-    consensus_downloads = os.path.join(results_path, "phyloConsensus")
+    consensus_downloads = os.path.join(fsx, "phyloConsensus")
     tree_path = os.path.join(results_path, "mega")
     # get samples from btb_wgs_samples.csv and filter
     samples_df = get_samples_df("s3-staging-area", "nickpestell/btb_wgs_samples.csv", **kwargs)

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -238,7 +238,7 @@ def append_multi_fasta(s3_bucket, s3_key, outfile, sample, consensus_path):
             file
     """
     # check if file is already present in the consensus directory 
-    consensus_filepath = os.path.join(consensus_path , sample , '.fas')
+    consensus_filepath = os.path.join(consensus_path , sample + '.fas')
     if not os.path.exists(consensus_filepath):
         # dowload consensus file from s3 to tempfile
         utils.s3_download_file(s3_bucket, s3_key, consensus_filepath)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -215,7 +215,7 @@ class TestBtbPhylo(unittest.TestCase):
         mock_open().read.side_effect=["AAA\nAAA", "TTT\nTTT", "CCC\nCCC", "GGG\nGGG"]
         # run build_multi_fasta() with test_df and a patched open
         with mock.patch("builtins.open", mock_open):
-            btb_phylo.build_multi_fasta("foo", test_df)
+            btb_phylo.build_multi_fasta("foo", test_df, '/mnt/fsx-017/phyloConsensus/')
         # calls to open to test against: 1 call for the output 
         # multifasta ("foo") and 4 calls for each consensus sequence
         open_calls = [mock.call("foo", "wb"), 

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -215,7 +215,7 @@ class TestBtbPhylo(unittest.TestCase):
         mock_open().read.side_effect=["AAA\nAAA", "TTT\nTTT", "CCC\nCCC", "GGG\nGGG"]
         # run build_multi_fasta() with test_df and a patched open
         with mock.patch("builtins.open", mock_open):
-            btb_phylo.build_multi_fasta("foo", test_df, '/mnt/fsx-017/phyloConsensus/')
+            btb_phylo.build_multi_fasta("foo", test_df, 'bar')
         # calls to open to test against: 1 call for the output 
         # multifasta ("foo") and 4 calls for each consensus sequence
         open_calls = [mock.call("foo", "wb"), 


### PR DESCRIPTION
This PR modifies btb-phylo.py to keep a directory of consensus files in fsx-017, and only download new ones when run

*Added new arguments for build_multi_fasta and append_multi_fasta
       -sample: pass row of sample being appended in to append_multi_fasta to allow the function to create a filepath based 
                      on sample name to download consensus fasta to, and check whether this exists.
        -consensus_path: filepath to folder on fsx-017 where consensus files are stored

* Modified append_multi_fasta to download and keep consensus files rather than deleting after each is appended. This allows user to only download new samples present in summary.df each time phylo is run

*Modified unit_tests.py to account for extra argument in build_multi_fasta
