### PR TITLE
Cli download patch

### DIFF
--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -241,7 +241,7 @@ def append_multi_fasta(s3_bucket, s3_key, outfile, sample, consensus_path):
     consensus_filepath = os.path.join(consensus_path , sample + '.fas')
     if not os.path.exists(consensus_filepath):
         # dowload consensus file from s3 to tempfile
-        utils.s3_download_file(s3_bucket, s3_key, consensus_filepath)
+        utils.s3_download_file_cli(s3_bucket, s3_key, consensus_filepath)
     # writes to multifasta
     with open(consensus_filepath, 'rb') as consensus_file:
         outfile.write(consensus_file.read())
@@ -343,6 +343,9 @@ def main():
     # command line arguments
     parser = argparse.ArgumentParser(description="btb-phylo")
     parser.add_argument("results_path", help="path to results directory")
+    parser.add_argument("consensus_path", help = "path to where consensus files will be held")
+    parser.add_argument("--download_only", help = "if only dowloading connsensus sequences",
+                        action="store_true", default=False)
     parser.add_argument("--n_threads", "-j", type=str, default=1, help="number of threads for snp-dists")
     parser.add_argument("--build_tree", action="store_true", default=False)
     parser.add_argument("--config", type=str, default=None)
@@ -353,15 +356,15 @@ def main():
     parser.add_argument("--n_count", "-nc", dest="Ncount", type=float, nargs=2)
     parser.add_argument("--flag", "-f", dest="flag", type=str, nargs="+")
     parser.add_argument("--meandepth", "-md", dest="MeanDepth", type=float, nargs=2)
-    parser.add_argument("--fsx_path", help = "Path to fsx drive where consensus files will be held", default='/mnt/fsx-017/')
     # parse agrs
     clargs = vars(parser.parse_args())
     # retreive "non-filtering" args
     results_path = clargs.pop("results_path")
+    consensus_path = clargs.pop("consensus_path")
+    download_only = clargs.pop("download_only")
     threads = clargs.pop("n_threads")
     tree = clargs.pop("build_tree")
     config = clargs.pop("config")
-    fsx = clargs.pop("fsx_path")
     # if config json file provided
     if config:
         error_keys = [key for key, val in clargs.items() if val]
@@ -380,21 +383,21 @@ def main():
     multi_fasta_path = os.path.join(results_path, "multi_fasta.fas")
     snp_sites_outpath = os.path.join(results_path, "snps.fas")
     snp_dists_outpath = os.path.join(results_path, "snp_matrix.tab")
-    consensus_downloads = os.path.join(fsx, "phyloConsensus")
     tree_path = os.path.join(results_path, "mega")
     # get samples from btb_wgs_samples.csv and filter
     samples_df = get_samples_df("s3-staging-area", "nickpestell/btb_wgs_samples.csv", **kwargs)
     # save df_summary (samples to include in VB) to csv
     samples_df.to_csv(summary_csv_path)
     # concatonate fasta files
-    build_multi_fasta(multi_fasta_path, samples_df, consensus_downloads) 
-    # run snp-sites
-    snp_sites(snp_sites_outpath, multi_fasta_path)
-    # run snp-dists
-    build_snp_matrix(snp_dists_outpath, snp_sites_outpath, threads)
-    # build tree
-    if tree:
-        build_tree(tree_path, snp_sites_outpath)
+    build_multi_fasta(multi_fasta_path, samples_df, consensus_path) 
+    if not download_only:
+        # run snp-sites
+        snp_sites(snp_sites_outpath, multi_fasta_path)
+        # run snp-dists
+        build_snp_matrix(snp_dists_outpath, snp_sites_outpath, threads)
+        # build tree
+        if tree:
+            build_tree(tree_path, snp_sites_outpath)
 
 if __name__ == "__main__":
     main()

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -201,7 +201,7 @@ class TestBtbPhylo(unittest.TestCase):
         with self.assertRaises(ValueError):
             btb_phylo.filter_columns_categorical(test_df, column_A=[1, 2, 3])
 
-    @mock.patch("btb_phylo.utils.s3_download_file")
+    @mock.patch("btb_phylo.utils.s3_download_file_cli")
     @mock.patch("btb_phylo.extract_s3_bucket")
     @mock.patch("btb_phylo.extract_s3_key")
     def test_build_multi_fasta(self, _, mock_extract_s3_bucket, mock_extract_s3_key):

--- a/update_summary.py
+++ b/update_summary.py
@@ -30,7 +30,7 @@ def finalout_csv_to_df(s3_key, s3_bucket="s3-csu-003"):
     """
     with tempfile.TemporaryDirectory() as temp_dirname:
         finalout_path = os.path.join(temp_dirname, "FinalOut.csv") 
-        utils.s3_download_file(s3_bucket, s3_key, finalout_path)
+        utils.s3_download_file_cli(s3_bucket, s3_key, finalout_path)
         return pd.read_csv(finalout_path, comment="#")
 
 def get_df_summary(bucket="s3-csu-003", key="v3-2/btb_wgs_samples.csv"):

--- a/utils.py
+++ b/utils.py
@@ -88,7 +88,6 @@ def run(cmd, *args, **kwargs):
             %s
             cmd failed with exit code %i
           *****""" % (cmd, returncode))
-
     if "capture_output" in kwargs and kwargs["capture_output"]:
         return ps.stdout.decode().strip('\n')
 
@@ -110,7 +109,7 @@ def s3_download_folder(bucket, key, dest):
 def s3_download_file(bucket, key, dest):
     """
         Downloads s3 folder at the key-bucket pair (strings) to dest 
-        path (string)
+        path (string) using boto3
     """
     if s3_object_exists(bucket, key):
         s3 = boto3.client('s3')
@@ -121,10 +120,10 @@ def s3_download_file(bucket, key, dest):
 def s3_download_file_cli(bucket, key, dest):
     """
         Downloads s3 folder at the key-bucket pair (strings) to dest 
-        path (string)
+        path (string) using the AWS CLI
     """
     if s3_object_exists(bucket, key):
-        run(["aws", "s3", "cp", f"s3://{bucket}/{key}", dest])
+        run(["aws", "s3", "cp", f"s3://{bucket}/{key}", dest], capture_output=True)
     else:
         raise NoS3ObjectError(bucket, key)
 

--- a/utils.py
+++ b/utils.py
@@ -116,6 +116,16 @@ def s3_download_file(bucket, key, dest):
     else:
         raise NoS3ObjectError(bucket, key)
 
+def s3_download_file_cli(bucket, key, dest):
+    """
+        Downloads s3 folder at the key-bucket pair (strings) to dest 
+        path (string)
+    """
+    if s3_object_exists(bucket, key):
+        run(["aws", "s3", "cp", f"s3://{bucket}/{key}", dest])
+    else:
+        raise NoS3ObjectError(bucket, key)
+
 def s3_upload_file(file, bucket, key):
     s3_client = boto3.client('s3')
     s3_client.upload_file(file, bucket, key)

--- a/utils.py
+++ b/utils.py
@@ -23,7 +23,8 @@ def summary_csv_to_df(bucket, summary_key):
     """
     with tempfile.TemporaryDirectory() as temp_dirname:
         summary_filepath = os.path.join(temp_dirname, "samples.csv")
-        s3_download_file(bucket, summary_key, summary_filepath)
+        # TODO: use s3_download_file() if boto3 is fixed
+        s3_download_file_cli(bucket, summary_key, summary_filepath)
         df = pd.read_csv(summary_filepath, comment="#", 
                          dtype = {"Sample":"category", "GenomeCov":float, 
                          "MeanDepth":float, "NumRawReads":float, "pcMapped":float, 
@@ -105,6 +106,7 @@ def s3_download_folder(bucket, key, dest):
     else:
         raise NoS3ObjectError(bucket, key)
 
+# TODO: remove if unused
 def s3_download_file(bucket, key, dest):
     """
         Downloads s3 folder at the key-bucket pair (strings) to dest 


### PR DESCRIPTION
This is a patch for fixing the `boto3` related error when downloading from s3.

Instead of using `boto3` to download files, the AWS CLI is used via a `subprocess` call. 

I have retained the `s3_download_file()` function for now in-case we switch back if the bug is fixed on `boto3`.

I have also changed the `fsx_path` argument to `consensus_path` to make it more general, in-case `btb-phylo` is run outside of fsx.