### PR TITLE
Light mode

### DIFF
--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -158,7 +158,7 @@ def phylo(results_path, consensus_path, download_only=False, n_threads=1,
         Pramaters:
             results_path (str):  output path to results directory
 
-            consenus_path (str):  output path to directory for saving consensus files
+            consenus_path (str): output path to directory for saving consensus files
 
             download_only (bool): only download consensus (do not run phylogeny)
 
@@ -180,6 +180,7 @@ def phylo(results_path, consensus_path, download_only=False, n_threads=1,
     metadata_path = os.path.join(results_path, "metadata")
     if not os.path.exists(metadata_path):
         os.makedirs(metadata_path)
+    metadata = {}
     # if df_filtered DataFrame provided
     if df_filtered is not None:
         pass
@@ -211,7 +212,7 @@ def phylo(results_path, consensus_path, download_only=False, n_threads=1,
     if not download_only:
         # run snp-sites
         print("\trunning snp_sites ... \n")
-        metadata = phylogeny.snp_sites(snp_sites_outpath, multi_fasta_path)
+        metadata.update(phylogeny.snp_sites(snp_sites_outpath, multi_fasta_path))
         # run snp-dists
         print("\trunning snp_dists ... \n")
         phylogeny.build_snp_matrix(snp_dists_outpath, snp_sites_outpath, n_threads)
@@ -247,8 +248,9 @@ def full_pipeline(results_path, consensus_path,
         # run phylogeny
         metadata_phylo, *_ = phylo(results_path, consensus_path, download_only, n_threads, 
                                    build_tree, df_filtered=df_consistified, light_mode=True)
-        # process sample names in snp_matrix to be consistent with cattle and movement data
-        phylogeny.post_process_snps_csv(os.path.join(results_path, "snp_matrix.csv"))
+        if not download_only:
+            # process sample names in snp_matrix to be consistent with cattle and movement data
+            phylogeny.post_process_snps_csv(os.path.join(results_path, "snp_matrix.csv"))
     else:
         # run phylogeny
         metadata_phylo, *_ = phylo(results_path, consensus_path, download_only, n_threads, 

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -13,6 +13,8 @@ import btbphylo.consistify as consistify
 import btbphylo.filter_samples as filter_samples
 import btbphylo.phylogeny as phylogeny
 
+# TODO: warning if setting consnesus directory to local path or using light_mode that there will need to be x amount of storage on the machine
+
 def update_samples(results_path, summary_filepath=utils.DEFAULT_SUMMARY_FILEPATH):
     """
         Updates the local copy of the sample summary csv file containing metadata 

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -168,7 +168,7 @@ def phylo(results_path, consensus_path, download_only=False, n_threads=1,
 
             filtered_filepath (str): optional input path to filtered samples csv
 
-            filtered_df (pandas dataframe object): optional dataframe containing 
+            filtered_df (pandas DataFrame object): optional dataframe containing 
             metadata for filtered samples
         
             light_mode (bool): If set to true multi_fasta.fas and snps.fas are


### PR DESCRIPTION
This PR introduces a `light-mode` flag which is used as an argument in `phylo()` function of `btb_phylo.py`. When set to `True`, this will save the `multi_fasta.fas` and `snsp.fas` in a temporary directory instead of `results_path`. 

This will be used by default when running for ViewBovine, because these are large files and will likely fill the space on `fsx-017`.