### PR TITLE
correct dtypes for FinalOut.csv

### DIFF
--- a/btbphylo/update_summary.py
+++ b/btbphylo/update_summary.py
@@ -27,6 +27,20 @@ def extract_s3_key(final_out_s3_object):
     """
     return final_out_s3_object.split(" ")[-1]
 
+def finalout_csv_to_df(finalout_filepath):
+    """
+        Reads finalout CSV and returns the data in a pandas dataframe.
+    """
+    df = pd.read_csv(finalout_filepath, comment="#", 
+                     dtype = {"Sample":"category", "GenomeCov":float, 
+                     "MeanDepth":float, "NumRawReads":float, "pcMapped":float, 
+                     "Outcome":"category", "flag":"category", "group":"category", 
+                     "CSSTested":float, "matches":float, "mismatches":float, 
+                     "noCoverage":float, "anomalous":float, "Ncount":float, 
+                     "ResultLoc":"category", "ID":"category", "TotalReads":float, 
+                     "Abundance":float})
+    return df
+
 def finalout_csv_to_df(s3_key, s3_bucket="s3-csu-003"):
     """
         Downloads FinalOut.csv files and writes to pandas dataframe
@@ -34,8 +48,7 @@ def finalout_csv_to_df(s3_key, s3_bucket="s3-csu-003"):
     with tempfile.TemporaryDirectory() as temp_dirname:
         finalout_path = path.join(temp_dirname, "FinalOut.csv") 
         utils.s3_download_file_cli(s3_bucket, s3_key, finalout_path)
-        #print(pd.read_csv(finalout_path, comment="#"))
-        return utils.finalout_csv_to_df(finalout_path)
+        return finalout_csv_to_df(finalout_path)
 
 def get_df_summary(summary_filepath=utils.DEFAULT_SUMMARY_FILEPATH):
     """

--- a/btbphylo/update_summary.py
+++ b/btbphylo/update_summary.py
@@ -34,7 +34,8 @@ def finalout_csv_to_df(s3_key, s3_bucket="s3-csu-003"):
     with tempfile.TemporaryDirectory() as temp_dirname:
         finalout_path = path.join(temp_dirname, "FinalOut.csv") 
         utils.s3_download_file_cli(s3_bucket, s3_key, finalout_path)
-        return pd.read_csv(finalout_path, comment="#")
+        #print(pd.read_csv(finalout_path, comment="#"))
+        return utils.finalout_csv_to_df(finalout_path)
 
 def get_df_summary(summary_filepath=utils.DEFAULT_SUMMARY_FILEPATH):
     """

--- a/btbphylo/utils.py
+++ b/btbphylo/utils.py
@@ -40,20 +40,6 @@ def summary_csv_to_df(summary_filepath):
                      "Abundance":float, "Submission": object})
     return df
 
-def finalout_csv_to_df(finalout_filepath):
-    """
-        Reads finalout CSV and returns the data in a pandas dataframe.
-    """
-    df = pd.read_csv(finalout_filepath, comment="#", 
-                     dtype = {"Sample":"category", "GenomeCov":float, 
-                     "MeanDepth":float, "NumRawReads":float, "pcMapped":float, 
-                     "Outcome":"category", "flag":"category", "group":"category", 
-                     "CSSTested":float, "matches":float, "mismatches":float, 
-                     "noCoverage":float, "anomalous":float, "Ncount":float, 
-                     "ResultLoc":"category", "ID":"category", "TotalReads":float, 
-                     "Abundance":float})
-    return df
-
 def extract_submission_no(sample_name):
     """ 
         Extracts submision number from sample name using regex. 

--- a/btbphylo/utils.py
+++ b/btbphylo/utils.py
@@ -28,7 +28,7 @@ def format_warning(message, category, filename, lineno, file=None, line=None):
 
 def summary_csv_to_df(summary_filepath):
     """
-        Downloads btb_wgs_samples.csv and returns the data in a pandas dataframe.
+        Read sample summary CSV and returns the data in a pandas dataframe.
     """
     df = pd.read_csv(summary_filepath, comment="#", 
                      dtype = {"Sample":"category", "GenomeCov":float, 
@@ -38,6 +38,20 @@ def summary_csv_to_df(summary_filepath):
                      "noCoverage":float, "anomalous":float, "Ncount":float, 
                      "ResultLoc":"category", "ID":"category", "TotalReads":float, 
                      "Abundance":float, "Submission": object})
+    return df
+
+def finalout_csv_to_df(finalout_filepath):
+    """
+        Reads finalout CSV and returns the data in a pandas dataframe.
+    """
+    df = pd.read_csv(finalout_filepath, comment="#", 
+                     dtype = {"Sample":"category", "GenomeCov":float, 
+                     "MeanDepth":float, "NumRawReads":float, "pcMapped":float, 
+                     "Outcome":"category", "flag":"category", "group":"category", 
+                     "CSSTested":float, "matches":float, "mismatches":float, 
+                     "noCoverage":float, "anomalous":float, "Ncount":float, 
+                     "ResultLoc":"category", "ID":"category", "TotalReads":float, 
+                     "Abundance":float})
     return df
 
 def extract_submission_no(sample_name):


### PR DESCRIPTION
This PR ensures that the FinalOut.csv files are loaded into memory with the correct dtypes so that subsequent mapping functions, e.g. `update_summary.add_submission_col()` will function correctly even is sample names have incorrect formatting.

This is achieved by an additional funtion `update_summary.finalout_csv_to_df()` which parses CSV columns with specific dtypes.  