### PR TITLE
use absolute path for all_samples.csv

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ This will download the latest docker image from [DockerHub](https://hub.docker.c
 │   ├── filters.json
 │   └── metadata.json
 ├── multi_fasta.fas
-├── snp_matrix.csv
+├── snps.csv
 └── snps.fas
 ```
 - `all_samples.csv`: a summary csv file containing metadata for all samples in `s3-csu-003`;
@@ -47,7 +47,7 @@ This will download the latest docker image from [DockerHub](https://hub.docker.c
 - `metadata.json`: a `.json` containing metadata for a `btb-phylo` run;
 - `multi_fasta.fas`: a fasta file containing consensus sequences for all samples included in the results;
 - `snps.fas`: a fasta file containing consensus sequences for all samples included in the results, where only snp sites are retained;
-- `snp_matrix.csv`: a snp matrix
+- `snps.csv`: a snp matrix
 
 ### Test with an example configuration file
 ```

--- a/btb-phylo.sh
+++ b/btb-phylo.sh
@@ -71,16 +71,17 @@ if [ $CONFIG == 0 ]; then
     echo "{}" > $CONFIG
 fi
 
+ALL_SAMPLES="$(dirname $(realpath $0))/all_samples.csv"
+
 # if running with docker 
 if [ $DOCKER == 1 ]; then
     printf "\nRunning btb-phylo with docker\n\n"
-    if [ ! -f all_samples.csv ]
+    if [ ! -f $ALL_SAMPLES ]
     then
         echo -e "Sample,GenomeCov,MeanDepth,NumRawReads,pcMapped,Outcome,flag,group,CSSTested,"\
             "matches,mismatches,noCoverage,anomalous,Ncount,ResultLoc,ID,TotalReads,Abundance,"\
-            "Submission" > all_samples.csv
+            "Submission" > $ALL_SAMPLES
     fi
-    ALL_SAMPLES=$(realpath all_samples.csv)
     if [ ! -d $RESULTS ]
     then
         mkdir $RESULTS

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -133,14 +133,14 @@ def consistify_samples(results_path, cat_mov_path):
             the same fields as the summary csv 
     """
     print("\n## Consistify ##\n")
-    # cattle and movements csv filepaths
+    # cattle and movement csv filepaths
     cattle_filepath = f"{cat_mov_path}/cattle.csv" 
-    movements_filepath = f"{cat_mov_path}/movements.csv" 
+    movements_filepath = f"{cat_mov_path}/movement.csv" 
     # validate paths
     if not os.path.exists(cattle_filepath):
         raise FileNotFoundError(f"Can't find cattle.csv in {cat_mov_path}")
     if not os.path.exists(movements_filepath):
-        raise FileNotFoundError(f"Can't find movements.csv in {cat_mov_path}")
+        raise FileNotFoundError(f"Can't find movement.csv in {cat_mov_path}")
     metadata_path = os.path.join(results_path, "metadata")
     filtered_filepath = os.path.join(metadata_path, "filtered_samples.csv")
     # consistified file outpaths
@@ -215,7 +215,7 @@ def phylo(results_path, consensus_path, download_only=False, n_threads=1,
     # output paths
     multi_fasta_path = os.path.join(fasta_path, "multi_fasta.fas")
     snp_sites_outpath = os.path.join(fasta_path, "snps.fas")
-    snp_dists_outpath = os.path.join(results_path, "snp_matrix.csv")
+    snp_dists_outpath = os.path.join(results_path, "snps.csv")
     tree_path = os.path.join(results_path, "mega")
     print("\n## Phylogeny ##\n")
     # concatonate fasta files
@@ -260,8 +260,8 @@ def full_pipeline(results_path, consensus_path,
         metadata_phylo, *_ = phylo(results_path, consensus_path, download_only, n_threads, 
                                    build_tree, df_filtered=df_consistified, light_mode=True)
         if not download_only:
-            # process sample names in snp_matrix to be consistent with cattle and movement data
-            phylogeny.post_process_snps_csv(os.path.join(results_path, "snp_matrix.csv"))
+            # process sample names in snps.csv to be consistent with cattle and movement data
+            phylogeny.post_process_snps_csv(os.path.join(results_path, "snps.csv"))
     else:
         # run phylogeny
         metadata_phylo, *_ = phylo(results_path, consensus_path, True, download_only, 
@@ -316,8 +316,8 @@ def view_bovine(results_path, consensus_path, cat_mov_path,
     # run phylogeny
     metadata_phylo, *_ = phylo(results_path, consensus_path, n_threads=4, 
                                df_filtered=df_consistified, light_mode=True)
-    # process sample names in snp_matrix to be consistent with cattle and movement data
-    phylogeny.post_process_snps_csv(os.path.join(results_path, "snp_matrix.csv"))
+    # process sample names in snps.csv to be consistent with cattle and movement data
+    phylogeny.post_process_snps_csv(os.path.join(results_path, "snps.csv"))
     metadata.update(metadata_phylo)
     return (metadata,)
 

--- a/btbphylo/phylogeny.py
+++ b/btbphylo/phylogeny.py
@@ -156,15 +156,15 @@ def post_process_snps_csv(snp_dists_outpath):
         An I/O layer for post_process_snps_df. Changes the sample names in the 
         snp matrix at snp_dists_outpath to be consistent with cattle and movement 
         datasets. This is necessary for serving ViewBovine:
-        Parses snp_matrix.csv.
+        Parses snps.csv.
         Runs post_process_snps_df().
-        Saves post processed snp matrix to the same location as the input snp_matrix.csv
+        Saves post processed snp matrix to the same location as the input snps.csv
     """
-    # load snp_matrix.csv
+    # load snps.csv
     snp_matrix = pd.read_csv(snp_dists_outpath, index_col=0)
     # process sample names
     processed_snp_matrix = post_process_snps_df(snp_matrix)
-    # overwrite input snp_matrix.csv with processed snp_matrix
+    # overwrite input snps.csv with processed snp_matrix
     processed_snp_matrix.to_csv(snp_dists_outpath)
 
 def post_process_snps_df(snp_matrix):


### PR DESCRIPTION
This bug fix ensures that the absolute path for the `all_samples.csv` that is located in the root of this repository is used in the bash script `btb-phylo.sh`. This is important for ViewBovine because the script that updates the data is run from the ViewBovine repo.