### PR TITLE
Remove nan

### DIFF
--- a/btbphylo/consistify.py
+++ b/btbphylo/consistify.py
@@ -56,6 +56,8 @@ def consistify(wgs, cattle, movements):
     wgs_consist = wgs.loc[wgs["Submission"].isin(consist_samples)]
     cattle_consist = cattle[cattle.CVLRef.isin(consist_samples)]
     movements_consist = movements[movements.SampleName.isin(consist_samples)]
+    # removes NaNs from Stay_Length column to avoid error in ViewBovine
+    movements_consist["Stay_Length"] = movements_consist["Stay_Length"].fillna(0)
     # metadata
     metadata = {"original_number_of_wgs_records": len(wgs),
                 "original_number_of_cattle_records": len(cattle),

--- a/btbphylo/consistify.py
+++ b/btbphylo/consistify.py
@@ -53,9 +53,9 @@ def consistify(wgs, cattle, movements):
     missing_cattle = pd.DataFrame({"CVLRef": list(cattle_samples - consist_samples)})
     missing_movement = pd.DataFrame({"SampleName": list(movement_samples - consist_samples)})
     # subsample full datasets by common names
-    wgs_consist = wgs.loc[wgs["Submission"].isin(consist_samples)]
-    cattle_consist = cattle[cattle.CVLRef.isin(consist_samples)]
-    movements_consist = movements[movements.SampleName.isin(consist_samples)]
+    wgs_consist = wgs.loc[wgs["Submission"].isin(consist_samples)].copy()
+    cattle_consist = cattle[cattle.CVLRef.isin(consist_samples)].copy()
+    movements_consist = movements[movements.SampleName.isin(consist_samples)].copy()
     # removes NaNs from Stay_Length column to avoid error in ViewBovine
     movements_consist["Stay_Length"] = movements_consist["Stay_Length"].fillna(0)
     # metadata

--- a/btbphylo/consistify.py
+++ b/btbphylo/consistify.py
@@ -57,7 +57,7 @@ def consistify(wgs, cattle, movements):
     cattle_consist = cattle[cattle.CVLRef.isin(consist_samples)].copy()
     movements_consist = movements[movements.SampleName.isin(consist_samples)].copy()
     # removes NaNs from Stay_Length column to avoid error in ViewBovine
-    movements_consist["Stay_Length"] = movements_consist["Stay_Length"].fillna(0)
+    movements_consist = movements_consist[movements_consist['Stay_Length'].notna()]
     # metadata
     metadata = {"original_number_of_wgs_records": len(wgs),
                 "original_number_of_cattle_records": len(cattle),

--- a/tests/consistify_test.py
+++ b/tests/consistify_test.py
@@ -10,7 +10,8 @@ class TestConsistify(unittest.TestCase):
         # test input
         test_wgs = pd.DataFrame({"Submission": ["A", "B", "C", "D"]})
         test_cattle = pd.DataFrame({"CVLRef": ["B", "C", "D"]})
-        test_movements = pd.DataFrame({"SampleName": ["C", "C", "D", "D", "D", "E"]})
+        test_movements = pd.DataFrame({"SampleName": ["C", "C", "D", "D", "D", "E"],
+                                       "Stay_Length": [None, 0, 0, 0, 0, 0]})
         # test output
         test_metadata = {"original_number_of_wgs_records": 4,
                          "original_number_of_cattle_records": 3,
@@ -20,7 +21,8 @@ class TestConsistify(unittest.TestCase):
                          "consistified_number_of_movement_records": 5}
         test_wgs_consist = pd.DataFrame({"Submission": ["C", "D"]})
         test_cattle_consist = pd.DataFrame({"CVLRef": ["C", "D"]})
-        test_movements_consist = pd.DataFrame({"SampleName": ["C", "C", "D", "D", "D"]})
+        test_movements_consist = pd.DataFrame({"SampleName": ["C", "C", "D", "D", "D"],
+                                               "Stay_Length": [0, 0, 0, 0, 0]})
         # run consistify
         (metadata, wgs_consist, cattle_consist, movements_consist, *_) = \
             consistify.consistify(test_wgs, test_cattle, test_movements)


### PR DESCRIPTION
This PR removes rows from `movement.csv` file for which `Stay_Length` column is NaN.

This is to fix a bug in BiewBovine when searching for offending samples:

`Traceback (most recent call last): File "/home/nickpestell/python-virtualenvs/ViewBovine/lib/python3.8/site-packages/flask/app.py", line 1523, in full_dispatch_request rv = self.dispatch_request() File "/home/nickpestell/python-virtualenvs/ViewBovine/lib/python3.8/site-packages/flask/app.py", line 1509, in dispatch_request return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args) File "/home/nickpestell/apha-csu/repos/ViewBovine/app/main.py", line 218, in sample_map req_movement = call_api('map', '/api/locations/{0}'.format(sample_name)) File "/home/nickpestell/apha-csu/repos/ViewBovine/app/main.py", line 101, in call_api return app.map.locations(path[15:]) File "/home/nickpestell/apha-csu/repos/ViewBovine/app/map.py", line 172, in locations 'StayLength': int(from_row['Stay_Length']), ValueError: cannot convert float NaN to integer`