### PR TITLE
Death row bug fix

### DIFF
--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -720,9 +720,6 @@ def parse_args():
         type=float, nargs=2, help="optional filter", default=(90, 100))
     subparser.add_argument("--flag", "-f", dest="flag", nargs="+", \
         help="optional filter", default=["BritishbTB"])
-    # TODO: remove this argument as it's just here for testing purposes
-    subparser.add_argument("--sample_name", "-s", dest="Sample", nargs="+", \
-        help="optional filter")
     subparser.set_defaults(func=view_bovine)
 
     # pasre args

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -702,7 +702,7 @@ def parse_args():
         nargs=2, help="optional filter")
     subparser.set_defaults(func=full_pipeline)
 
-    # view bovine
+    # viewbovine
     subparser = subparsers.add_parser('ViewBovine', help="runs phylogeny with \
         default settings for ViewBovine")
     subparser.add_argument("results_path", help="path to results directory")
@@ -720,6 +720,9 @@ def parse_args():
         type=float, nargs=2, help="optional filter", default=(90, 100))
     subparser.add_argument("--flag", "-f", dest="flag", nargs="+", \
         help="optional filter", default=["BritishbTB"])
+    # TODO: remove this argument as it's just here for testing purposes
+    subparser.add_argument("--sample_name", "-s", dest="Sample", nargs="+", \
+        help="optional filter")
     subparser.set_defaults(func=view_bovine)
 
     # pasre args

--- a/btbphylo/consistify.py
+++ b/btbphylo/consistify.py
@@ -75,9 +75,13 @@ def clade_correction(df_wgs, df_cattle):
 # TODO: move this feature into sql scripts in ViewBovine repo
 def fix_movement(df_movement):
     """
-        removes NaNs from Stay_Length column to avoid error in ViewBovine
+        removes NaNs from Stay_Length column to avoid error in 
+        ViewBovine
     """
-    return df_movement[df_movement['Stay_Length'].fillna(0)]
+    df_movement_fixed = df_movement.copy()
+    df_movement_fixed['Stay_Length'] = \
+        df_movement_fixed['Stay_Length'].fillna(0)
+    return df_movement_fixed
 
 def process_datasets(df_wgs, df_cattle, df_movement):
     """

--- a/btbphylo/consistify.py
+++ b/btbphylo/consistify.py
@@ -72,17 +72,6 @@ def clade_correction(df_wgs, df_cattle):
             df_wgs.loc[df_wgs["Submission"]==row["CVLRef"], "group"].iloc[0]
     return df_cattle_corrected
 
-# TODO: move this feature into sql scripts in ViewBovine repo
-def fix_movement(df_movement):
-    """
-        removes NaNs from Stay_Length column to avoid error in 
-        ViewBovine
-    """
-    df_movement_fixed = df_movement.copy()
-    df_movement_fixed['Stay_Length'] = \
-        df_movement_fixed['Stay_Length'].fillna(0)
-    return df_movement_fixed
-
 def process_datasets(df_wgs, df_cattle, df_movement):
     """
         Fully processes the datasets so that they are prepped for 
@@ -96,8 +85,6 @@ def process_datasets(df_wgs, df_cattle, df_movement):
         consistify(df_wgs.copy(), df_cattle.copy(), df_movement.copy())
     # correct clade assignment in cattle csv
     df_cattle_corrected = clade_correction(df_wgs_consist, df_cattle_consist)
-    # fix movement data
-    df_fixed_movement = fix_movement(df_movement_consist)
     # metadata
     metadata = {"original_number_of_wgs_records": len(df_wgs),
                 "original_number_of_cattle_records": len(df_cattle),
@@ -107,7 +94,7 @@ def process_datasets(df_wgs, df_cattle, df_movement):
                     len(df_cattle_corrected),
                 "consistified_number_of_movement_records": \
                     len(df_movement_consist)}
-    return metadata, df_wgs_consist, df_cattle_corrected, df_fixed_movement
+    return metadata, df_wgs_consist, df_cattle_corrected, df_movement_consist
 
 def consistify_csvs(wgs_samples_path, cattle_path, movement_path, 
                     consistified_wgs_path, consistified_cattle_path, 

--- a/btbphylo/consistify.py
+++ b/btbphylo/consistify.py
@@ -77,7 +77,7 @@ def fix_movement(df_movement):
     """
         removes NaNs from Stay_Length column to avoid error in ViewBovine
     """
-    return df_movement[df_movement['Stay_Length'].notna()]
+    return df_movement[df_movement['Stay_Length'].fillna(0)]
 
 def process_datasets(df_wgs, df_cattle, df_movement):
     """


### PR DESCRIPTION
This PR is in-line with https://github.com/aphascience/ViewBovine/pull/84#issue-1449685365.

Basically, entries where "Stay_Length=Null" in `movement.csv` have been changed to "Stay_Length=0" due to https://github.com/aphascience/ViewBovine/pull/84#issue-1449685365.

Thus, these entries can remain in the data because they will not break ViewBovine app.

Therefore I have removed the `fix_movement()` function.