### PR TITLE
View bovine gunicorn systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__
 all_wgs_samples.csv
+.vscode
+.ViewBovine_consensus/
+.ViewBovine_results/


### PR DESCRIPTION
This PR adds directories to the `.gitignore`. These two directories are for the results and the downloaded consensus sequences. In the original ViewBovine workflow these were going to an FSX share, but now they're stored locally in the root directory of the repo, hence why they have been added to the `.gitignore`.

I have also made some minor changes to the main run script. Essentially to avoid breaking an empty config file is generated and saved in the root of the repo, if one isn't provided as an argument, this was a bit of a hack. Originally, this file was not being cleaned up which was annoying because it just sits in the repo and I can see it when running `git status` etc. The changes I have made are just to delete the file after the script runs.