### PR TITLE
New filters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -187,11 +187,11 @@ Updating the snp-matrix is triggered manually and should be run either weekly or
 
 ### Updating the snp-matrix
 
-1. Mount FSx drive, `fsx-ranch-017`;
-2. Mount FSx drive, `fsx-042`;
-2. Run the following command; 
+1. Ensure that the dev machine has write access to `s3-ranch-042`;
+2. Update a local copy of cattle and movement metadata (details of how to do this is are in the [ViewBovine readme](https://github.com/aphascience/ViewBovine))
+3. Run the ViewBovine update script; 
 ```
-./btb-phylo.sh {fsx-017_path}/ViewBovine/app/prod {fsx-042_path}/share/ViewBovine_consensus --meta_path {fsx-017_path}/ViewBovine/app/raw --with-docker
+bash ViewBovine/scipts/update.bash {path/to/directory/containing/cattle/and/movement/csvs}
 ```
 **By default the results directory will contain:**
 ```
@@ -211,7 +211,7 @@ Updating the snp-matrix is triggered manually and should be run either weekly or
 ├── snps.csv
 └── snps.fas
 ```
-This will use predefined filtering criteria to download new samples to `fsx-017`, consistify the samples with cattle and movement data and update the snp-matrix on `fsx-017`. 
+This will use predefined filtering criteria to download new samples to a local directory in this repo, consistify the samples with cattle and movement data and update the snp-matrix. It will then push the results up to `s3-ranch-042`. 
 
 ## <a name="config-file"></a> Configuration file
 

--- a/ViewBovineDataFlow.md
+++ b/ViewBovineDataFlow.md
@@ -57,7 +57,7 @@ The below screen grab shows the `report.csv`.
 
 <img src="https://user-images.githubusercontent.com/10742324/198324636-0ab48e96-53a3-4f17-8c65-51a5272849f3.PNG" width="400">
 
-The first column indicates the submission number of each excluded submission. The next four columns; `Outcome`, `flag`, `pcMapped` and `Ncount` relate to filtering of WGS samples. For a sample to pass filtering, the `flag` column must be "BritishbTB" and the `Outcome`, `pcMapped` and `Ncount` columns must all be "Pass".
+The first column indicates the submission number of each excluded submission and the next column is the eartag number. The next two columns; `Outcome` and `Ncount` relate to filtering of WGS samples. For a sample to pass filtering, the `Outcome` and `Ncount` columns must both be "Pass".
 
 If the sample passes filtering, to be included in ViewBovine, it must also exist in the `wgs`, `cattle` and `movement` datasets; that is, the value must be "TRUE" for all three of these columns. 
 

--- a/ViewBovine_update.bash
+++ b/ViewBovine_update.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+META_PATH=$2
+
+# backup production files
+# skip the backup stage if the prod/ folder is missing in s3-ranch-042
+{
+    # extract date of current production files from s3-ranch-042
+    aws s3 cp s3://s3-ranch-042/prod/metadata/metadata.json . &&
+    {
+	backup_datetime=($(sed -e 's/^"//' -e 's/"$//' <<< $(jq '.datetime' metadata.json)))
+	backup_date=${backup_datetime[0]}
+	rm metadata.json
+
+	# backup current production files in s3-ranch-042
+	aws s3 mv --recursive s3://s3-ranch-042/prod/ s3://s3-ranch-042/${backup_date}/ --acl bucket-owner-full-control
+    }
+}
+
+# delete production files if still existing
+aws s3 rm --recursive s3://s3-ranch-042/prod/
+
+# run btb-phylo 
+consensus_path=.ViewBovine_consensus
+mkdir -p ${consensus_path}
+./btb-phylo.sh .ViewBovine_results ${consensus_path} --meta_path ${META_PATH}  --with-docker
+
+# upload new production files to s3-ranch-042
+aws s3 cp --recursive .ViewBovine_results/ s3://s3-ranch-042/prod/ --acl bucket-owner-full-control

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -716,8 +716,6 @@ def parse_args():
     subparser.add_argument("--all_wgs_samples_filepath", help="path to \
         'all_wgs_samples' .csv file", \
             default=utils.DEFAULT_WGS_SAMPLES_FILEPATH)
-    subparser.add_argument("--flag", "-f", dest="flag", nargs="+", \
-        help="optional filter", default=["nonBritishbTB", "BritishbTB"])
     subparser.set_defaults(func=view_bovine)
 
     # pasre args

--- a/btb_phylo.py
+++ b/btb_phylo.py
@@ -716,10 +716,8 @@ def parse_args():
     subparser.add_argument("--all_wgs_samples_filepath", help="path to \
         'all_wgs_samples' .csv file", \
             default=utils.DEFAULT_WGS_SAMPLES_FILEPATH)
-    subparser.add_argument("--pcmapped", "-pc", dest="pcMapped", \
-        type=float, nargs=2, help="optional filter", default=(90, 100))
     subparser.add_argument("--flag", "-f", dest="flag", nargs="+", \
-        help="optional filter", default=["BritishbTB"])
+        help="optional filter", default=["nonBritishbTB", "BritishbTB"])
     subparser.set_defaults(func=view_bovine)
 
     # pasre args

--- a/btbphylo/missing_samples_report.py
+++ b/btbphylo/missing_samples_report.py
@@ -23,10 +23,7 @@ def exclusion_reason(df_wgs_excluded, df_clade_info):
         is excluded.
     """
     # subsample df_excluded columns
-    df_report = df_wgs_excluded[["Submission", "Outcome", "flag"]].copy()
-    # map pcMapped column to a pass/fail value
-    df_report["pcMapped"] = df_wgs_excluded["pcMapped"]\
-        .map(lambda x: "Pass" if x >= 90 else "Fail")
+    df_report = df_wgs_excluded[["Submission", "Outcome"]].copy()
     # map Ncount column to a pass/fail value
     df_report["Ncount"] = "Fail"
     for clade, row in df_clade_info.iterrows():
@@ -52,8 +49,6 @@ def missing_data(df_report, missing_wgs_samples, missing_cattle_samples,
     df_report_missing_wgs = \
         pd.DataFrame({"Submission": list(missing_wgs_samples), 
                       "Outcome": [None]*len(missing_wgs_samples),
-                      "flag": [None]*len(missing_wgs_samples),
-                      "pcMapped": [None]*len(missing_wgs_samples),
                       "Ncount": [None]*len(missing_wgs_samples),
                       "wgs_data": [False]*len(missing_wgs_samples),
                       "cattle_data": [None]*len(missing_wgs_samples),

--- a/tests/missing_samples_report_test.py
+++ b/tests/missing_samples_report_test.py
@@ -19,8 +19,6 @@ class TestMissingSamplesReport(unittest.TestCase):
         # test input
         test_df_excluded = pd.DataFrame({"Submission": ["A", "B", "C"],
                                          "Outcome": ["foo", "bar", "baz"],
-                                         "flag": ["foo", "bar", "baz"],
-                                         "pcMapped": [90, 91, 89],
                                          "Ncount": [3, 2, 1],
                                          "group": ["clade_a", "clade_b", "clade_c"]})
         test_df_clade_info = pd.DataFrame({"maxN": [2, 2, 2]}, 
@@ -28,8 +26,6 @@ class TestMissingSamplesReport(unittest.TestCase):
         # test output
         test_df_report = pd.DataFrame({"Submission": ["A", "B", "C"],
                                        "Outcome": ["foo", "bar", "baz"],
-                                       "flag": ["foo", "bar", "baz"],
-                                       "pcMapped": ["Pass", "Pass", "Fail"],
                                        "Ncount": ["Fail", "Pass", "Pass"]})
         # assert output
         nptesting.assert_array_equal(missing_samples_report.exclusion_reason(test_df_excluded,
@@ -43,8 +39,6 @@ class TestMissingSamplesReport(unittest.TestCase):
                                                       "missing_movement",
                                                       "missing_cattle_&_movement"],
                                        "Outcome": ["foo", "bar", "baz", "foobar"],
-                                       "flag": ["foo", "bar", "baz", "foobar"],
-                                       "pcMapped": ["foo", "bar", "baz", "foobar"],
                                        "Ncount": ["foo", "bar", "baz", "foobar"]})
         test_missing_wgs_samples = {"missing_wgs"}
         test_missing_cattle_samples = {"missing_cattle", "missing_cattle_&_movement"}
@@ -56,8 +50,6 @@ class TestMissingSamplesReport(unittest.TestCase):
                                                                    "missing_cattle_&_movement",
                                                                    "missing_wgs"],
                                                     "Outcome": ["foo", "bar", "baz", "foobar", None],
-                                                    "flag": ["foo", "bar", "baz", "foobar", None],
-                                                    "pcMapped": ["foo", "bar", "baz", "foobar", None],
                                                     "Ncount": ["foo", "bar", "baz", "foobar", None],
                                                     "wgs_data": [True, True, True, True, False],
                                                     "cattle_data": [True, False, True, False, True],


### PR DESCRIPTION
This pr implements a few changes, but most importantly it reduces the filters down to:

1. pass only
2. BritishbTB and nonBritishbTB -> I believe this effectively the same as pass?
3. Ncount thresholds

These filters are now more-or-less in line with btb-forestry, aside from some minor discrepancies in the values of N thresholds and I have not yet implement outlier removal. I have noticed that without pcMapped filter the number of samples increases a long with the number of SNPs.

In practice this involved simply removing the optional argument pcMapped argument from the main python script (Lines 719-720) and adding an additional "nonBritishbTB" to the `flag` filter. I was also required to adapt the `missing_sample_report.py` module and it's unit test. 

Additionally I have included the ViewBovine update script in this repo as well as the ViewBovine repo: not really sure where it should sit ...

I have updated the readme - in line with the new server architecture on `ranch-159` for viewbovine.
